### PR TITLE
Extends metrics to keep track of OCISAppsMetric and OCISUniqUsers

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
 var pushFlag bool
 var prefixFlag string
 var carbonServerFlag string
@@ -48,6 +47,12 @@ func main() {
 	uniqSamba := samba.NewUniqUsers()
 	pattern = path.Join("/data/log/", today, "box.samba*/*/td.var.log.samba.smbclients.log")
 	metrics = append(metrics, parse(pattern, uniqSamba)...)
+
+	// analyze OCIS logs
+	OCISappsMetrics := revad.NewOCISAppsMetric()
+	OCISuniqWeb := revad.NewOCISUniqUsers()
+	pattern = path.Join("/data/log/", today, "box.ocis*/*/td.var.log.revad-gateway.log")
+	metrics = append(metrics, parse(pattern, OCISappsMetrics, OCISuniqWeb)...)
 
 	// send to carbon
 	push(metrics)

--- a/revad/revad.go
+++ b/revad/revad.go
@@ -23,6 +23,10 @@ type line struct {
 	Environment string    `json:"environment"`
 	Time        time.Time `json:"time"`
 	Username    string    `json:"username"`
+	Path        string    `json:"path"`
+	Agent       string    `json:"agent"`
+	User        string    `json:"user"`
+	Country     string    `json:"country"`
 }
 
 type UserCreated struct {
@@ -79,6 +83,78 @@ func NewUniqUsers() *UniqUsers {
 func (uu *UniqUsers) Metrics() map[string]int {
 	m := map[string]int{
 		"users.web": len(uu.dist),
+	}
+	return m
+}
+
+//Apps used metric scanning for OCIS specific app identifiers
+type OCISAppsMetric struct {
+	dist map[string]int
+}
+
+func (uu *OCISAppsMetric) Do(data []byte) {
+	l := &line{}
+
+	if err := jsoniter.Unmarshal([]byte(data), l); err != nil {
+		er(err)
+	}
+
+	if strings.Contains(l.Path, "/text-editor") {
+		uu.dist["OCIS.apps.usage.OCIStext-editor"]++
+	} else if strings.Contains(l.Path, "/*.docx?app=MS'%'20365'%'20on'%'20Cloud") {
+		uu.dist["OCIS.apps.usage.word"]++
+	} else if strings.Contains(l.Path, "/draw-io") {
+		uu.dist["OCIS.apps.usage.OCISdrawio"]++
+	} else if strings.Contains(l.Path, "/*.md?app=CodiMD") {
+		uu.dist["OCIS.apps.usage.CodiMD"]++
+	} else if strings.Contains(l.Path, "/*.xlsx?app=MS'%'20365'%'20on'%'20Cloud") {
+		uu.dist["OCIS.apps.usage.excel"]++
+	} else if strings.Contains(l.Path, "/*.pptx?app=MS'%'20365'%'20on'%'20Cloud") {
+		uu.dist["OCIS.apps.usage.pwpoint"]++
+	} else if strings.Contains(l.Path, "/*.odt?app=Collabora") {
+		uu.dist["OCIS.apps.usage.openDoc"]++
+	} else if strings.Contains(l.Path, "/*.ods?app=Collabora") {
+		uu.dist["OCIS.apps.usage.openSpread"]++
+	} else if strings.Contains(l.Path, "/*.odp?app=Collabora") {
+		uu.dist["OCIS.apps.usage.openSlide"]++
+	}
+
+}
+
+func NewOCISAppsMetric() *OCISAppsMetric {
+	return &OCISAppsMetric{
+		dist: map[string]int{},
+	}
+}
+
+func (uu *OCISAppsMetric) Metrics() map[string]int {
+	return uu.dist
+}
+
+//metric that keeps track of Unique OCIS Users 
+type OCISUniqUsers struct {
+	dist map[string]int
+}
+
+func (uu *OCISUniqUsers) Do(data []byte) {
+	l := &line{}
+
+	if err := jsoniter.Unmarshal([]byte(data), l); err != nil {
+		er(err)
+	}
+
+	if l.User != "" {
+		uu.dist[l.User]++
+	}
+}
+
+func NewOCISUniqUsers() *OCISUniqUsers {
+	return &OCISUniqUsers{dist: map[string]int{}}
+}
+
+func (uu *OCISUniqUsers) Metrics() map[string]int {
+	m := map[string]int{
+		"users.OCISweb": len(uu.dist),
 	}
 	return m
 }


### PR DESCRIPTION
This addition allows for the addition of metrics specific for OCIS. For example, the OCISAppsMetric uses new strings to indentify what applications are being used based on an OCIS URL. 